### PR TITLE
Fixes to allow build on MSYS2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,10 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
+# DB: check if max_align_t is defined
+AC_CHECK_TYPES([max_align_t])
+
+
 # Checks for library functions.
 AC_FUNC_ALLOCA
 AC_FUNC_ERROR_AT_LINE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,6 +101,7 @@ b_em_SOURCES = \
 	vidalleg.c \
 	video.c \
 	wd1770.c \
+	win.c \
 	x86.c \
 	x86dasm.c \
 	resid-fp/convolve-sse.cc \

--- a/src/tsearch.c
+++ b/src/tsearch.c
@@ -127,7 +127,7 @@ typedef void (*__action_fn_t) (const void *__nodep, VISIT __value, int __level);
  *    data this function should do nothing.  */
 typedef void (*__free_fn_t) (void *__nodep);
 
-#ifndef __CLANG_MAX_ALIGN_T_DEFINED
+#ifndef HAVE_MAX_ALIGN_T
 typedef long double max_align_t;
 #endif
 


### PR DESCRIPTION
win.c was not being included in the default makefile and detection for type max_align_t was broken